### PR TITLE
Add resource request/limits to JHub feature

### DIFF
--- a/src/jupyterhub/bin/setup-jupyterhub.sh
+++ b/src/jupyterhub/bin/setup-jupyterhub.sh
@@ -159,6 +159,13 @@ spec:
   
   jupyterWorkspace:
     image: lscsde/datascience-notebook-default:0.1.0
+    resources:
+      requests:
+        memory: "256M"
+        cpu: 0.15
+      limits:
+        memory: "512M"
+        cpu: 0.25
     
     tolerations:
     - key: "sdeAppType"

--- a/src/jupyterhub/bin/setup-jupyterhub.sh
+++ b/src/jupyterhub/bin/setup-jupyterhub.sh
@@ -97,6 +97,13 @@ spec:
     image: lscsde/datascience-notebook-default:0.1.0
     persistentVolumeClaim: 
       name: jupyter-default-generic-workspace
+    resources:
+      requests:
+        memory: "256M"
+        cpu: 0.1
+      limits:
+        memory: "1G"
+        cpu: 0.5
 ---
 apiVersion: xlscsde.nhs.uk/v1
 kind: AnalyticsWorkspace
@@ -120,6 +127,15 @@ spec:
   
   jupyterWorkspace:
     image: lscsde/datascience-notebook-default:0.1.0
+    persistentVolumeClaim: 
+      name: jupyter-test-workspace
+    resources:
+      requests:
+        memory: "256M"
+        cpu: 0.1
+      limits:
+        memory: "1G"
+        cpu: 0.5
 ---
 apiVersion: xlscsde.nhs.uk/v1
 kind: AnalyticsWorkspace
@@ -139,6 +155,15 @@ spec:
   
   jupyterWorkspace:
     image: lscsde/docker-datascience-jupyter-omop:darwin-v1.4.0-amd64
+    persistentVolumeClaim: 
+      name: jupyter-omop-darwin-workspace
+    resources:
+      requests:
+        memory: "256M"
+        cpu: 0.1
+      limits:
+        memory: "1G"
+        cpu: 0.5
 EOF
 kubectl apply -f workspaces.yaml
 
@@ -170,7 +195,7 @@ spec:
 apiVersion: xlscsde.nhs.uk/v1
 kind: AnalyticsWorkspaceBinding
 metadata:
-  name: omoooop-workspace-jovyan
+  name: omop-workspace-jovyan
   namespace: jh-test
   annotations:
     kustomize.toolkit.fluxcd.io/prune: disabled

--- a/src/jupyterhub/jupyterhub.values.yaml
+++ b/src/jupyterhub/jupyterhub.values.yaml
@@ -1,0 +1,9 @@
+hub:
+  image:
+    name: k3d-devcontainer-registry.local:36471/jupyterhub
+    tag: local
+    pullPolicy: Always
+  extraEnv:
+    DEFAULT_STORAGE_CLASS: "jupyter-default"
+    DEFAULT_STORAGE_ACCESS_MODES: "ReadWriteOnce"
+    DEFAULT_STORAGE_CAPACITY: "1Gi"


### PR DESCRIPTION
Add requests and limits for workspaces. Smoke tests below.

ToDo: 

- [ ] Fail faster when pod cannot be deployed on devcontainer environment to allow faster iteration.

# Smoke Tests

## Hub spawn page
![image](https://github.com/user-attachments/assets/9a608038-2fde-44a1-baeb-4ac5213e4996)

## Successful failure of workspace with tolerations
![image](https://github.com/user-attachments/assets/73badba4-bcc2-4e02-8673-fc4226bf8283)

